### PR TITLE
Fix naming of Avatar.jsx

### DIFF
--- a/frontend/src/components/Navbar/Avatar.jsx
+++ b/frontend/src/components/Navbar/Avatar.jsx
@@ -4,7 +4,7 @@ import {Link } from 'react-router-dom'
 import {useNavigate, useLocation} from 'react-router'
 import {useDispatch} from 'react-redux'
 
-function avatar(){
+function Avatar(){
     const dispatch = useDispatch();
     const navigate = useNavigate();
     const [user, setUser] = useState(JSON.parse(localStorage.getItem('profile')));
@@ -75,4 +75,4 @@ function avatar(){
     )
 }
 
-export default avatar 
+export default Avatar 


### PR DESCRIPTION
As suggested in the title, the component inside the file should have capitalized first letter (in conformity with React guidelines). Thus, the component has been renamed with a capitalized first letter.